### PR TITLE
Back office: list widget support

### DIFF
--- a/components/admin/data/widgets/form/component.js
+++ b/components/admin/data/widgets/form/component.js
@@ -82,7 +82,7 @@ class WidgetForm extends PureComponent {
             tableName: _dataset.tableName,
             slug: _dataset.slug
           })),
-          widgetMetadata: current.metadata[0]
+          widgetMetadata: current && current.metadata[0]
         });
       })
       .catch((err) => {
@@ -106,7 +106,7 @@ class WidgetForm extends PureComponent {
         ...form,
         widgetConfig,
         name,
-        description,
+        description
       };
 
       if (formObj.sourceUrl === '') {

--- a/components/admin/data/widgets/form/constants.js
+++ b/components/admin/data/widgets/form/constants.js
@@ -57,16 +57,16 @@ export const NEW_WIDGET_TYPES = [LIST_WIDGET_TYPE, COMBINED_WIDGET_TYPE, DYNAMIC
 
 export const LIST_WIDGET_TEMPLATE = {
   type: 'widget',
-  name: 'widget-name',
+  name: 'Test widget list',
   description: 'widget-description',
   widgetConfig: {
     type: 'list',
     listWidgetConfig: {
-      heading: 'this-is-the-heading-of-the-list',
-      query: 'enter the data query here',
+      heading: 'These are the first 5 values for land temperature: ',
+      query: 'https://api.resourcewatch.org/v1/query/47dc1a1b-2c91-4d69-b04e-ea8c4561e2b5?sql=SELECT date as key , no_smoothing as value FROM cli_044_global_land_temperature ORDER BY no_smoothing desc LIMIT 5',
       format: '0.2s',
-      bullets: true,
-      numbers: false
+      bullets: false,
+      numbers: true
     }
   }
 };

--- a/components/admin/data/widgets/form/preview/component.js
+++ b/components/admin/data/widgets/form/preview/component.js
@@ -5,6 +5,7 @@ import Renderer from '@widget-editor/renderer';
 
 // components
 import CombinedWidget from 'components/widgets/combined';
+import ListWidget from 'components/widgets/list';
 
 // styles
 import './styles.scss';
@@ -16,6 +17,7 @@ function WidgetPreview(props) {
   const useRenderer = ['map', 'chart'].includes(widgetType);
   const isEmbed = widgetType === 'embed';
   const isCombined = widgetType === 'combined';
+  const isList = widgetType === 'list';
   const widgetEmbedUrl = isEmbed && widgetConfig.url;
 
   return (
@@ -24,7 +26,7 @@ function WidgetPreview(props) {
     >
       {useRenderer &&
         <Renderer widgetConfig={widgetConfig} />
-            }
+      }
       {isEmbed &&
         <iframe
           title={widget.name}
@@ -33,12 +35,17 @@ function WidgetPreview(props) {
           height="100%"
           frameBorder="0"
         />
-            }
+      }
       {isCombined &&
         <CombinedWidget
           widget={widget}
         />
-            }
+      }
+      {isList &&
+        <ListWidget
+          widget={widget}
+        />
+      }
     </div>
   );
 }

--- a/components/admin/data/widgets/form/steps/Step1.js
+++ b/components/admin/data/widgets/form/steps/Step1.js
@@ -6,15 +6,15 @@ import RwAdapter from '@widget-editor/rw-adapter';
 // Redux
 import { connect } from 'react-redux';
 
+// Utils
+import DefaultTheme from 'utils/widgets/theme';
+
 // Components
 import Field from 'components/form/Field';
 import Select from 'components/form/SelectInput';
 import Checkbox from 'components/form/Checkbox';
 import RadioGroup from 'components/form/RadioGroup';
 import WidgetPreview from '../preview';
-
-// Utils
-import DefaultTheme from 'utils/widgets/theme';
 
 // Constants
 import {
@@ -46,14 +46,14 @@ class Step1 extends Component {
       NEW_WIDGET_TYPES.includes(widgetType);
     const defaultCode = isNewWidgetType ?
       NEW_WIDGET_TYPES_TEMPLATES.find(e => e.id === widgetType).value
-      : NEW_WIDGET_TYPES_TEMPLATES[0];
+      : NEW_WIDGET_TYPES_TEMPLATES[0].value;
 
     this.state = {
       id,
       form,
       showNewWidgetsInterface: !!id && isNewWidgetType,
       newWidgetTypesEditorCode: id ? JSON.stringify(form, null, 5) : JSON.stringify(defaultCode, null, 5),
-      previewSource: !!id && !!form && form 
+      previewSource: !!id && !!form && form
     };
   }
 

--- a/components/widgets/list/component.js
+++ b/components/widgets/list/component.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { toastr } from 'react-redux-toastr';
+
+// components
+import Spinner from 'components/ui/Spinner';
+
+// styles
+import './styles.scss';
+
+function ListWidget(props) {
+  const { widget } = props;
+  const widgetConfig = widget && widget.widgetConfig;
+  const listWidgetConfig = widgetConfig && widgetConfig.listWidgetConfig;
+  const { heading, query, numbers, bullets, format } = listWidgetConfig || {};
+  const [loading, setLoading] = useState(true);
+  const [listData, setListdata] = useState([]);
+
+  useEffect(() => {
+    setLoading(true);
+
+    fetch(query)
+      .then(resp => resp.json())
+      .then((response) => {
+        setListdata(response.data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        toastr.error(`There was an error loading the widget ${widget.name} query: ${err}`);
+      });
+  }, [query, widget]);
+
+  const ListTag = numbers ? 'ol' : 'ul';
+
+  return (
+    <div className="c-list-widget">
+      <Spinner isLoading={loading} className="-relative -light" />
+      <div className="list-heading">
+        {heading}
+      </div>
+      <ListTag>
+        {listData.map(elem =>
+            <li>
+                {elem.key}: {elem.value}
+            </li>
+        )}
+      </ListTag>
+    </div>
+  );
+}
+
+ListWidget.propTypes = { widget: PropTypes.object.isRequired };
+
+export default ListWidget;

--- a/components/widgets/list/component.js
+++ b/components/widgets/list/component.js
@@ -28,7 +28,7 @@ function ListWidget(props) {
       .catch((err) => {
         toastr.error(`There was an error loading the widget ${widget.name} query: ${err}`);
       });
-  }, [query, widget]);
+  }, [widget]);
 
   const ListTag = numbers ? 'ol' : 'ul';
 

--- a/components/widgets/list/index.js
+++ b/components/widgets/list/index.js
@@ -1,0 +1,3 @@
+import ListWidgetComponent from './component';
+
+export default ListWidgetComponent;

--- a/components/widgets/list/styles.scss
+++ b/components/widgets/list/styles.scss
@@ -1,0 +1,25 @@
+@import 'css/settings';
+
+.c-list-widget {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    position: relative;
+
+    ul, ol {
+        list-style: circle inside;   
+    }
+
+    li {
+        display: flex;
+        margin-left: 5 * $space;
+    }
+
+    ol {
+        list-style-type: decimal;
+    }
+
+    ul {
+        list-style-type: circle;
+    }
+}

--- a/components/widgets/list/styles.scss
+++ b/components/widgets/list/styles.scss
@@ -11,7 +11,7 @@
     }
 
     li {
-        display: flex;
+        display: list-item;
         margin-left: 5 * $space;
     }
 


### PR DESCRIPTION
![imagen](https://user-images.githubusercontent.com/545342/92454260-98ee7280-f1c0-11ea-9a08-e833afe3184c.png)

## Overview
This PR adds support for list type widgets in the back office.

## Testing instructions
Check this URL as an example: http://localhost:9000/admin/data/widgets/241418fa-d679-4462-98e8-e8deeb84fbb2/edit?dataset=47dc1a1b-2c91-4d69-b04e-ea8c4561e2b5

## [Pivotal task](https://www.pivotaltracker.com/story/show/174693243)